### PR TITLE
Changes to the Yang->Polymer extract.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.connectifex</groupId>
 	<artifactId>polymer</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 
 	<name>dark-matter-polymer</name>
 	<url>https://github.com/dark-matter-org/dark-matter-polymer</url>

--- a/src/main/java/com/connectifex/polymer/mdl/shared/dmconfig/types.dmd
+++ b/src/main/java/com/connectifex/polymer/mdl/shared/dmconfig/types.dmd
@@ -2,3 +2,11 @@
 
 // This a placeholder file for type definitions.
 
+EnumDefinition
+name             HierarchyTypeEnum
+nullReturnValue	 PlasticResultEnum.OKAY
+enumValue		0 CONTAINER		A container
+enumValue		1 OBJECT_LIST 	An object list
+enumValue		2 LEAF_LIST 	A leaf list.
+enumValue		3 USES_LIST 	A uses list.
+enumValue		4 GROUPING 		A grouping.

--- a/src/main/java/com/connectifex/polymer/mdl/tools/yang/VariableManager.java
+++ b/src/main/java/com/connectifex/polymer/mdl/tools/yang/VariableManager.java
@@ -1,0 +1,142 @@
+package com.connectifex.polymer.mdl.tools.yang;
+
+import java.util.Stack;
+import java.util.TreeMap;
+
+import org.dmd.util.formatting.PrintfFormat;
+
+import com.connectifex.polymer.mdl.server.extended.plastic.util.PlasticGlobals;
+import com.connectifex.polymer.mdl.tools.yang.util.ChoiceInfo;
+import com.connectifex.polymer.mdl.tools.yang.util.VariableInfo;
+import com.connectifex.polymer.mdl.tools.yang.util.YangStructure;
+
+/**
+ * The VariableManager manages a set of Polymer variables and ensures that they unique
+ * names depending on where they exist in a YangStructure hierarchy.
+ */
+public class VariableManager {
+
+	private TreeMap<String,VariableInfo>	variablesByName;
+	private int longest;
+
+	// These are injected 
+	private Stack<ChoiceInfo>				choiceStack;
+	private Stack<String>					caseStack;
+
+	// Used in cases where we need to generate a unique name because we don't
+	// have a parent element. We increment this as required.
+	private int								uniqueID;
+
+	public VariableManager(Stack<ChoiceInfo> choiceStack, Stack<String> caseStack) {
+		this.variablesByName = new TreeMap<>();
+		
+		this.choiceStack	= choiceStack;
+		this.caseStack		= caseStack;
+	}
+	
+	/**
+	 * The name of the variable has to be unique, so we maintain a set of names associated
+	 * with the JSON schema we're building up. We also take care of indicating that the variable is embedded
+	 * within an array and putting [] at the end of its name.
+	 * If a variable is duplicated, we proceed up the hierarchy appending previous parent names until 
+	 * we get something unique.
+	 * @param yang
+	 * @return
+	 */
+	public VariableInfo addVariable(YangStructure yang) {
+		PlasticGlobals.instance().trace("addVariable: " + yang.getFullyQualifiedName());
+		
+		String name = yang.name();
+		if (yang.isInList())
+			name = name + "[]";
+		
+		ChoiceInfo choice = null;
+		if (choiceStack.size() > 0) {
+			PlasticGlobals.instance().trace("CHOICE " + choiceStack.peek().name());
+			choice = choiceStack.peek();
+		}
+		if (caseStack.size() > 0) {
+			PlasticGlobals.instance().trace("CASE " + caseStack.peek());
+		}
+
+		VariableInfo existing = variablesByName.get(name);
+
+		if (existing == null) {
+			existing = new VariableInfo(name, yang);
+			variablesByName.put(existing.name(), existing);
+		}
+		else {
+			// We already have a variable with this name, so recurse up the tree, prepending parent
+			// names until we get something unique
+			YangStructure parent = yang.parent();
+			while(true) {
+				if (parent == null) {
+//					PlasticGlobals.instance().trace("Could not create unique name based on hierarchy!");
+//					PlasticGlobals.instance().trace("For YangStructure: " + yang.name() + " fqn: " + yang.getFullyQualifiedName());
+//					System.exit(1);
+					
+					name = name + "--" + uniqueIdSuffix();
+					
+					existing = variablesByName.get(name);
+					if (existing == null) {
+						existing = new VariableInfo(name, yang);
+						variablesByName.put(existing.name(), existing);
+						break;
+					}
+
+					PlasticGlobals.instance().trace("Could not create unique name based on hierarchy!");
+					PlasticGlobals.instance().trace("For YangStructure: " + yang.name() + " fqn: " + yang.getFullyQualifiedName());
+					System.exit(1);
+
+				}
+				else {
+					name = parent.name() + "--" + name;
+					
+					existing = variablesByName.get(name);
+					if (existing == null) {
+						existing = new VariableInfo(name, yang);
+						variablesByName.put(existing.name(), existing);
+						break;
+					}
+					parent = parent.parent();
+				}
+			}
+		}
+		
+		if (existing.name().length() > longest)
+			longest = existing.name().length();
+		
+		if (choice != null) {
+			choice.addVariable(caseStack.peek(), existing);
+			existing.setChoice(choice);
+		}
+		
+		return(existing);
+	}
+
+	
+	public void getVariables(StringBuilder sb) {
+		longest += 4;
+		PrintfFormat format = new PrintfFormat("%-" + longest + "s");
+
+		for(VariableInfo var: variablesByName.values()) {
+			sb.append(var.toVariableFormat(format) + "\n");
+		}
+		
+	}
+	
+	private String uniqueIdSuffix() {
+		String rc = "";
+		if (uniqueID < 10)
+			rc = "00" + uniqueID;
+		else if (uniqueID < 100)
+			rc = "0" + uniqueID;
+		else
+			rc = "" + uniqueID;
+		
+		uniqueID++;
+		
+		return(rc);
+	}
+
+}

--- a/src/main/java/com/connectifex/polymer/mdl/tools/yang/YangToPolymerHierarchy.java
+++ b/src/main/java/com/connectifex/polymer/mdl/tools/yang/YangToPolymerHierarchy.java
@@ -24,10 +24,9 @@ import org.dmd.dmc.types.IntegerVar;
 import org.dmd.dmu.util.json.PrettyJSON;
 import org.dmd.util.exceptions.DebugInfo;
 import org.dmd.util.formatting.PrintfFormat;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import com.connectifex.polymer.mdl.server.extended.plastic.util.PlasticGlobals;
+import com.connectifex.polymer.mdl.shared.generated.enums.HierarchyTypeEnum;
 import com.connectifex.polymer.mdl.tools.yang.util.ChoiceInfo;
 import com.connectifex.polymer.mdl.tools.yang.util.Helper;
 import com.connectifex.polymer.mdl.tools.yang.util.ModuleVersion;
@@ -35,15 +34,18 @@ import com.connectifex.polymer.mdl.tools.yang.util.VariableInfo;
 import com.connectifex.polymer.mdl.tools.yang.util.YangAttribute;
 import com.connectifex.polymer.mdl.tools.yang.util.YangConstants;
 import com.connectifex.polymer.mdl.tools.yang.util.YangContext;
+import com.connectifex.polymer.mdl.tools.yang.util.YangHierarchyNode;
 import com.connectifex.polymer.mdl.tools.yang.util.YangStructure;
 
 /**
- * The YangToPolymer class will attempt to find top level containers or augment statements
+ * The YangToPolymerHierarchy class will attempt to find top level containers or augment statements
  * and generate partial InputSchemas that have the input schema and variable definitions.
+ * This new approach also allows for the creation of multiple input schemas distinguished
+ * by their unique paths.
  */
-public class YangToPolymer {
+public class YangToPolymerHierarchy {
 	
-	private JSONObject						object;
+//	private JSONObject						topLevelObject;
 	private YangStructure					module;
 	private TreeMap<String,VariableInfo>	variablesByName;
 	private int longest;
@@ -61,7 +63,12 @@ public class YangToPolymer {
 	// have a parent element. We increment this as required.
 	private int								uniqueID;
 	
-	public YangToPolymer() {
+	// We maintain the containers that exist in the overall hierarhcy so that
+	// we can generate a set of individual input schemas, with their associated
+	// paths.
+	private ArrayList<YangHierarchyNode>	allContainers;
+	
+	public YangToPolymerHierarchy() {
 		// TODO Auto-generated constructor stub
 	}
 	
@@ -80,20 +87,31 @@ public class YangToPolymer {
 			choiceUsageCount	= new TreeMap<>();
 			choiceStack 		= new Stack<>();
 			caseStack 			= new Stack<>();
+			allContainers		= new ArrayList<>();
 			
 			YangStructure container = containers.next();
 			
-			object = new JSONObject();
-			descend(container, "", 1, object);
+			YangHierarchyNode	topLevelNode = new YangHierarchyNode(HierarchyTypeEnum.CONTAINER, null, container);
+			allContainers.add(topLevelNode);
+			
+//			topLevelObject = new JSONObject();
+//			descend(container, "", 1, topLevelObject);
 			
 //			PlasticGlobals.instance().trace(PrettyJSON.instance().prettyPrint(object, true));
 						
-			dumpInputSchema(module,version);
+			dumpInputSchema(module,version,topLevelNode);
 			anyThingDumped = true;
 			
 			for(ChoiceInfo choice: choicesByUniqueName.values()) {
 				System.out.println(choice.toYangChoice() + "\n");
 			}
+			
+			System.out.println("// Containers\n");
+			for (YangHierarchyNode node: allContainers) {
+				System.out.println(node.getSchema(version));
+			}
+			System.out.println();
+
 		}
 		
 		ArrayList<YangAttribute> attrs = module.attribute(YangConstants.USES);
@@ -110,18 +128,29 @@ public class YangToPolymer {
 						choiceUsageCount	= new TreeMap<>();
 						choiceStack 		= new Stack<>();
 						caseStack 			= new Stack<>();
+						allContainers		= new ArrayList<>();
 						
-						object = new JSONObject();
-						descend(grouping, "", 1, object);
+//						topLevelObject = new JSONObject();
+//						descend(grouping, "", 1, topLevelObject);
+						
+						YangHierarchyNode	topLevelNode = new YangHierarchyNode(HierarchyTypeEnum.GROUPING, null, grouping);
+						descend(grouping, "", 1, topLevelNode);
 						
 	//					PlasticGlobals.instance().trace(PrettyJSON.instance().prettyPrint(object, true));
 									
-						dumpInputSchema(module,version);
+						dumpInputSchema(module,version,topLevelNode);
 						anyThingDumped = true;
 						
 						for(ChoiceInfo choice: choicesByUniqueName.values()) {
 							System.out.println(choice.toYangChoice() + "\n");
 						}
+						
+						System.out.println("-- containers\n");
+						for (YangHierarchyNode node: allContainers) {
+							System.out.println(node.getSchema(version));
+						}
+						System.out.println();
+
 					}
 				}
 	
@@ -134,27 +163,34 @@ public class YangToPolymer {
 		
 	}
 	
-	private void dumpInputSchema(YangStructure module, ModuleVersion version) {
-		longest += 4;
-		PrintfFormat format = new PrintfFormat("%-" + longest + "s");
-		StringBuilder sb = new StringBuilder();
-		sb.append("InputSchema\n");
-		sb.append("name            " + module.name() + "\n");
-		for(VariableInfo var: variablesByName.values()) {
-			sb.append(var.toVariableFormat(format) + "\n");
-		}
-		sb.append("inputSchema " + PrettyJSON.instance().prettyPrint(object, true, "  ") + "\n");
-		sb.append("description Generated from: " + version.nameAndRevision() + " - variables: " + variablesByName.size());
+	private void dumpInputSchema(YangStructure module, ModuleVersion version, YangHierarchyNode topLevelNode) {
+		System.out.println("NOTE: skipping export of top level structure...\n");
+//		longest += 4;
+//		PrintfFormat format = new PrintfFormat("%-" + longest + "s");
+//		StringBuilder sb = new StringBuilder();
+//		sb.append("InputSchema\n");
+//		sb.append("name            " + module.name() + "\n");
+//		for(VariableInfo var: variablesByName.values()) {
+//			sb.append(var.toVariableFormat(format) + "\n");
+//		}
+//		sb.append("inputSchema " + PrettyJSON.instance().prettyPrint(topLevelNode.object(), true, "  ") + "\n");
+//		sb.append("description Generated from: " + version.nameAndRevision() + " - variables: " + variablesByName.size());
+//		
+//		System.out.println(sb.toString());
 		
-		System.out.println(sb.toString());
+
 	}
 	
-	public void descend(YangStructure node, String indent, int depth, JSONObject object) {
+//	public void descend(YangStructure node, String indent, int depth, JSONObject object) {
+	public void descend(YangStructure node, String indent, int depth, YangHierarchyNode parentNode) {
 		PlasticGlobals.instance().trace(indent + node.type() + "  " + node.name() + "  depth: " + depth + " children: " + node.childrenSize());
 		
 		if (node.type().equals(YangConstants.CONTAINER)) {
-			JSONObject containerObj = new JSONObject();
-			object.put(node.name(), containerObj);
+//			JSONObject containerObj = new JSONObject();
+//			object.put(node.name(), containerObj);
+			
+			YangHierarchyNode hierarchyNode = new YangHierarchyNode(HierarchyTypeEnum.CONTAINER, parentNode, node);
+			allContainers.add(hierarchyNode);
 			
 			ArrayList<YangAttribute> uses = node.attribute(YangConstants.USES);
 			if (uses != null) {
@@ -168,7 +204,7 @@ public class YangToPolymer {
 						throw(new IllegalStateException("Could not find grouping: " + attr.value()));
 					}
 					else {
-						descend(grouping, indent + "    ", depth+1, containerObj);
+						descend(grouping, indent + "    ", depth+1, hierarchyNode);
 					}
 				}
 			}
@@ -176,7 +212,7 @@ public class YangToPolymer {
 			Iterator<YangStructure> children = node.children();
 			while(children.hasNext()) {
 				YangStructure child = children.next();
-				descend(child, indent + "    ", depth+1, containerObj);
+				descend(child, indent + "    ", depth+1, hierarchyNode);
 			}
 			
 		}
@@ -193,7 +229,7 @@ public class YangToPolymer {
 						throw(new IllegalStateException("Could not find grouping: " + attr.value()));
 					}
 					else {
-						descend(grouping, indent + "    ", depth+1, object);
+						descend(grouping, indent + "    ", depth+1, parentNode);
 					}
 				}
 			}
@@ -201,15 +237,24 @@ public class YangToPolymer {
 			Iterator<YangStructure> children = node.children();
 			while(children.hasNext()) {
 				YangStructure child = children.next();
-				descend(child, indent + "    ", depth+1, object);
+				descend(child, indent + "    ", depth+1, parentNode);
 			}
 		}
 		else if (node.type().equals(YangConstants.LIST)) {
-			JSONArray array = new JSONArray();
-			object.put(node.name(), array);
+//			JSONArray array = new JSONArray();
+//			object.put(node.name(), array);
 			
 			ArrayList<YangAttribute> uses = node.attribute(YangConstants.USES);
+			
+			YangHierarchyNode objectListNode = null;
+			if ( (uses != null) || (node.childrenSize() > 1)) {
+				PlasticGlobals.instance().trace(indent + "OBJECT list");
+				objectListNode = new YangHierarchyNode(HierarchyTypeEnum.OBJECT_LIST, parentNode, node);
+			}
+			
 			if (uses != null) {
+//				YangHierarchyNode usesNode = new YangHierarchyNode(HierarchyTypeEnum.USES_LIST, parentNode, node);
+				
 				PlasticGlobals.instance().trace(indent + "Uses entries: " + uses.size());
 				for(YangAttribute attr: uses) {
 					PlasticGlobals.instance().trace(indent + "Uses: " + attr.value() + "\n");		
@@ -220,29 +265,36 @@ public class YangToPolymer {
 						throw(new IllegalStateException("Could not find grouping: " + attr.value()));
 					}
 					else {
-						descend(grouping, indent + "    ", depth+1, object);
+//						descend(grouping, indent + "    ", depth+1, parentNode);
+						descend(grouping, indent + "    ", depth+1, objectListNode);
 					}
 				}
 			}
 
-			if (node.childrenSize() == 1) {
+			if (node.childrenSize() == 1) {				
 				PlasticGlobals.instance().trace(indent + "leaf list");
+				YangHierarchyNode leafListNode = new YangHierarchyNode(HierarchyTypeEnum.LEAF_LIST, parentNode, node);
 				
 				// Some trickery here, we actually use the child as the basis for
 				// the variable.
 				VariableInfo info = addVariable(node.getChild(0), indent);
 				
-				array.put(info.variableInsert());
+//				array.put(info.variableInsert());
+				
+				leafListNode.addVariable(info);
 			}
 			else {
 				PlasticGlobals.instance().trace(indent + "OBJECT list");
-				JSONObject newobj = new JSONObject();
-				array.put(newobj);
+//				JSONObject newobj = new JSONObject();
+//				array.put(newobj);
+
+//				YangHierarchyNode objectListNode = new YangHierarchyNode(HierarchyTypeEnum.OBJECT_LIST, parentNode, node);
+
 				
 				Iterator<YangStructure> children = node.children();
 				while(children.hasNext()) {
 					YangStructure child = children.next();
-					descend(child, indent + "    ", depth+1, newobj);
+					descend(child, indent + "    ", depth+1, objectListNode);
 				}
 
 			}
@@ -252,17 +304,24 @@ public class YangToPolymer {
 			
 			VariableInfo info = addVariable(node, indent);
 
-			object.put(node.name(), info.variableInsert());
+//			object.put(node.name(), info.variableInsert());
+			
+			parentNode.addVariable(info);
 		}
 		else if (node.type().equals(YangConstants.LEAF_LIST)) {
-			JSONArray array = new JSONArray();
-			object.put(node.name(), array);
+//			JSONArray array = new JSONArray();
+//			object.put(node.name(), array);
+			
+			YangHierarchyNode leafListNode = new YangHierarchyNode(HierarchyTypeEnum.LEAF_LIST, parentNode, node);
 
 			PlasticGlobals.instance().trace(indent + "leaf-list");
 			
 			VariableInfo info = addVariable(node, indent);
 
-			array.put(info.variableInsert());
+//			array.put(info.variableInsert());
+			
+			leafListNode.addVariable(info);
+			
 		}
 		else {
 			// NOTE: very complicated handling for CHOICE/CASE statements
@@ -300,7 +359,8 @@ public class YangToPolymer {
 			Iterator<YangStructure> children = node.children();
 			while(children.hasNext()) {
 				YangStructure child = children.next();
-				descend(child, indent + "    ", depth+1, object);
+//				descend(child, indent + "    ", depth+1, object);
+				descend(child, indent + "    ", depth+1, parentNode);
 			}
 			
 			if (node.type().equals(YangConstants.CHOICE)) {

--- a/src/main/java/com/connectifex/polymer/mdl/tools/yang/YangUtil.java
+++ b/src/main/java/com/connectifex/polymer/mdl/tools/yang/YangUtil.java
@@ -190,8 +190,15 @@ public class YangUtil {
 			return;
 		}
 		
-		YangToPolymer ytp = new YangToPolymer();
-		ytp.convert(context,root,version);
+		// NOTE: this was the old style extract that only showed the entire structure with no path
+		// information - the new form shows the leaf contains complete with their path
+//		YangToPolymer ytp = new YangToPolymer();
+//		ytp.convert(context,root,version);
+//		
+//		System.out.println("\n\nHIERARCHY\n\n");
+		
+		YangToPolymerHierarchy ytph = new YangToPolymerHierarchy();
+		ytph.convert(context, root, version);
 		
 //		Iterator<YangStructure> it = context.getAllLoadedModules();
 //		while(it.hasNext()) {

--- a/src/main/java/com/connectifex/polymer/mdl/tools/yang/util/VariableInfo.java
+++ b/src/main/java/com/connectifex/polymer/mdl/tools/yang/util/VariableInfo.java
@@ -185,6 +185,13 @@ public class VariableInfo {
 	public String name() {
 		return(name);
 	}
+	
+	/**
+	 * @return the YangStructure associated with this variable
+	 */
+	public YangStructure structure() {
+		return(yang);
+	}
 		
 	/**
 	 * @return the plastic variable specification with ${ }
@@ -227,6 +234,36 @@ public class VariableInfo {
 		
 		if (description!= null)
 			sb.append(" note=\"" + description +"\"");
+		
+		if (type!= null)
+			sb.append(" type=\"" + type +"\"");
+		
+		if (units!= null)
+			sb.append(" units=\"" + units +"\"");
+		
+		// We don't add this is there's only a single case
+		if (choice != null && choice.moreThanOneCase())
+			sb.append(" choice=" + choice.uniqueName() + "");
+			
+		return(sb.toString());
+	}
+
+	/**
+	 * Dumps the variable without the (sometimes lengthy) description note
+	 * @param format the 
+	 * @return
+	 */
+	public String toVariableFormatNoNote(PrintfFormat format) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("variables ");
+		
+		sb.append(format.sprintf(variableInsert));
+		
+		if (defaultValue != null)
+			sb.append(" default=\"" + defaultValue + "\"");
+		
+//		if (description!= null)
+//			sb.append(" note=\"" + description +"\"");
 		
 		if (type!= null)
 			sb.append(" type=\"" + type +"\"");

--- a/src/main/java/com/connectifex/polymer/mdl/tools/yang/util/YangHierarchyNode.java
+++ b/src/main/java/com/connectifex/polymer/mdl/tools/yang/util/YangHierarchyNode.java
@@ -1,0 +1,244 @@
+package com.connectifex.polymer.mdl.tools.yang.util;
+
+import java.util.ArrayList;
+import java.util.TreeMap;
+
+import org.dmd.dmc.types.IntegerVar;
+import org.dmd.dmu.util.json.PrettyJSON;
+import org.dmd.util.formatting.PrintfFormat;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import com.connectifex.polymer.mdl.shared.generated.enums.HierarchyTypeEnum;
+
+/**
+ * The YangHierarchyNode class represents a node in the overall Yang hierarchy.
+ * This allows us to create paths to containers so that we can generate input
+ * schemas and their associated path.
+ */
+public class YangHierarchyNode {
+	
+	private HierarchyTypeEnum				type;
+	
+	// This container's parent, or null if this is a top level container
+	private YangHierarchyNode				parent;
+	
+	// The children from this point in the hierarchy
+	private ArrayList<YangHierarchyNode>	children;
+	
+	// The structure that defined this container/grouping
+	private YangStructure					structure;
+	
+	// The object at this level of the container hierarchy
+	private JSONObject						object;
+	
+	// Or, if this a list, we'll have an array
+	private JSONArray						array;
+	
+	// When dump the schemas, we're primarily interested in leaf containers, but
+	// in the case where we have a non-leaf container in the middle of the hierarchy
+	// that has leaf elements, we want those containers as well - this flag is
+	// set if we add a variable to an OBJECT_LIST type
+	private boolean							hasLeafOrLLeafLists;
+	
+	private TreeMap<String,VariableInfo>	variablesByName;
+	private int								longest;
+
+	public YangHierarchyNode(HierarchyTypeEnum type, YangHierarchyNode parent, YangStructure structure) {
+		this.type		= type;
+		this.parent		= parent;
+		this.structure	= structure;
+		
+		children		= new ArrayList<>();
+		variablesByName = new TreeMap<>();
+		
+		switch(type) {
+		case CONTAINER:
+		case GROUPING:
+			object	= new JSONObject();
+			if (parent != null)
+				parent.object.put(structure.name(), object);
+			array	= null;
+			break;
+		case USES_LIST:
+		case LEAF_LIST:
+			object	= null;
+			array	= new JSONArray();
+			if (parent != null)
+				parent.object.put(structure.name(), array);
+			break;
+		case OBJECT_LIST:
+			array	= new JSONArray();
+			object	= new JSONObject();
+			
+			array.put(object);
+			if (parent != null)
+				parent.object.put(structure.name(), array);
+			break;
+		}
+		
+		if (parent != null)
+			parent.children.add(this);
+	}
+	
+	/**
+	 * @return our JSON object.
+	 */
+	public JSONObject object() {
+		if (object == null)
+			throw(new IllegalStateException("This isn't a container - no object is available"));
+		
+		return(object);
+	}
+	
+	/**
+	 * @return our array if we're an array.
+	 */
+	public JSONArray array() {
+		if (array == null)
+			throw(new IllegalStateException("This isn't a list - no array is available"));
+		
+		return(array);
+	}
+	
+	public void addVariable(VariableInfo info) {
+		switch(type) {
+		case CONTAINER:
+			object.put(info.structure().name(), info.variableInsert());
+			break;
+		case LEAF_LIST:
+			array.put(info.variableInsert());
+			break;
+		case OBJECT_LIST:
+			hasLeafOrLLeafLists = true;
+			object.put(info.structure().name(), info.variableInsert());
+			break;
+		case GROUPING:
+		case USES_LIST:
+			throw(new IllegalStateException("Can't add a variable to a node of type: " + type));
+		}
+		
+		variablesByName.put(info.name(), info);
+		if (info.name().length() > longest)
+			longest = info.name().length();
+	}
+	
+	public String getSchema(ModuleVersion version) {
+		StringBuilder sb = new StringBuilder();
+		
+//		sb.append(structure.getFullyQualifiedName() + "\n\n");
+
+		StringBuilder path = new StringBuilder();
+		getPath(path);
+		
+		if (isLeafContainer()) {
+			sb.append("// leaf container: " + isLeafContainer() + "\n");
+			
+			IntegerVar longestName = new IntegerVar();
+			TreeMap<String,VariableInfo> variablesHere = new TreeMap<>();
+			gatherVariables(variablesHere,longestName);
+			longestName.set(longestName.intValue() + 4);
+			
+			PrintfFormat format = new PrintfFormat("%-" + longestName.intValue() + "s");
+			
+			sb.append("InputSchema\n");
+			sb.append("name            " + structure.getFullyQualifiedName() + "\n");
+			sb.append("path            " + path.toString() + "\n");
+	
+			for(VariableInfo var: variablesHere.values()) {
+//				sb.append(var.toVariableFormat(format) + "\n");
+				sb.append(var.toVariableFormatNoNote(format) + "\n");
+			}
+	
+			sb.append("inputSchema " + PrettyJSON.instance().prettyPrint(object, true, "  ") + "\n");
+			sb.append("description Generated from: " + version.nameAndRevision() + " - variables: " + variablesHere.size() + "\n");
+			sb.append("\n");
+		}
+		else {
+			if (hasLeafOrLLeafLists) {
+				sb.append("// non-leaf container with leaf(s)\n");
+				sb.append("InputSchema\n");
+				sb.append("name            " + structure.getFullyQualifiedName() + "\n");
+				sb.append("path            " + path.toString() + "\n");
+				sb.append("inputSchema " + PrettyJSON.instance().prettyPrint(object, true, "  ") + "\n");
+				
+			}
+			else {
+				sb.append("// non-leaf container with no leaf value\n");
+				sb.append("path            " + path.toString() + "\n");
+//				sb.append("InputSchema\n");
+//				sb.append("name            " + structure.getFullyQualifiedName() + "\n");
+//				sb.append("path            " + path.toString() + "\n");
+//				sb.append("inputSchema " + PrettyJSON.instance().prettyPrint(object, true, "  ") + "\n");
+			}
+		}
+		
+		return(sb.toString());
+	}
+	
+	private boolean isLeafContainer() {
+		boolean rc = true;
+		
+		if (children.size() == 0) {
+			
+		}
+		else {
+			for(YangHierarchyNode child: children) {
+				if (child.type == HierarchyTypeEnum.CONTAINER) {
+					rc = false;
+					break;
+				}
+				
+				if (child.isLeafContainer()) {
+					
+				}
+				else {
+					rc = false;
+					break;
+				}
+				
+			}
+		}
+		
+		return(rc);
+	}
+	
+	private void gatherVariables(TreeMap<String,VariableInfo> variables, IntegerVar longestName) {
+		for(VariableInfo info:variablesByName.values()) {
+			variables.put(info.name(), info);
+			if (info.name().length() > longestName.intValue())
+				longestName.set(info.name().length());
+		}
+		
+		for(YangHierarchyNode child: children) {
+			if (child.isLeafContainer()) {
+				child.gatherVariables(variables,longestName);
+			}
+		}		
+	}
+	
+	private void getPath(StringBuilder path) {
+		switch(type) {
+		case CONTAINER:
+			path.insert(0, "/" + structure.name());
+			break;
+		case GROUPING:
+			break;
+		case LEAF_LIST:
+			break;
+		case OBJECT_LIST:
+			YangAttribute key = structure.singleAttribute(YangStructure.KEY);
+			if (key == null)
+				path.insert(0, "/" + structure.name() + "[]");
+			else
+				path.insert(0, "/" + structure.name() + "[" + key.value() + "]");
+				
+			break;
+		case USES_LIST:
+			break;
+		}
+		if (parent != null)
+			parent.getPath(path);
+		
+	}
+}

--- a/src/main/java/com/connectifex/polymer/mdl/tools/yang/util/YangStructure.java
+++ b/src/main/java/com/connectifex/polymer/mdl/tools/yang/util/YangStructure.java
@@ -37,10 +37,12 @@ import org.dmd.util.exceptions.ResultException;
  */
 public class YangStructure {
 	
-	private static String NACM = "nacm";
-	private static String INCLUDE = "include";
-	private static String IMPORT = "import";
-	private static String GROUPING = "grouping";
+	public static String NACM		= "nacm";
+	public static String INCLUDE	= "include";
+	public static String IMPORT		= "import";
+	public static String GROUPING	= "grouping";
+	public static String CONTAINER	= "container";
+	public static String KEY		= "key";
 
 	private String type;
 	private String name;
@@ -783,6 +785,21 @@ public class YangStructure {
 		return(depth);
 	}
     
+    public TreeMap<String, YangHierarchyNode> getPaths(){
+    	if (parent != null)
+    		throw(new IllegalStateException("Should only call this on the root."));
+    	
+    	TreeMap<String, YangHierarchyNode> rc = new TreeMap<String, YangHierarchyNode>();
+    	
+    	pathDescent(null, rc);
+    	
+    	return(rc);
+    }
     
+    private void pathDescent(YangHierarchyNode parent, TreeMap<String, YangHierarchyNode> paths) {
+    	if (type.equals(CONTAINER)) {
+    		
+    	}
+    }
 
 }

--- a/src/test/java/com/connectifex/polymer/mdl/tools/yang/YangUtilTest.java
+++ b/src/test/java/com/connectifex/polymer/mdl/tools/yang/YangUtilTest.java
@@ -81,7 +81,7 @@ public class YangUtilTest {
 
 			String[] args = { "-srcdirs", openconfigDir, ietfDir, 
 					"-file", "openconfig-routing-policy",
-					"-trace",
+//					"-trace",
 //					"-plasticdir", plasticdir
 			};
 


### PR DESCRIPTION
Previously, we had simply exported the entire parameterized structure,
which was interesting but not useful in an actual application. When
altering Yang config, a user has to have the complete path to a
container being manipulated. Determining this complete is tedious - if
you look at the tree view for OpenConfig Yang here:
http://ops.openconfig.net/branches/models/master/ you'll see deep
structures from which you can infer the paths, but it would take you a
while to do so.

The YangUtil can now analyze and provide a list of all "leaf"
containers, complete with their paths.

For example:

InputSchema
name            prefix-set-top_gr--prefix-sets--prefix-set--config
path            /routing-policy/defined-sets/prefix-sets/prefix-set[name]/config
variables ${mode}  type="enum - IPV4/IPV6/MIXED"
variables ${name}  type="string"
inputSchema {
    "mode": "${mode}",
    "name": "${name}"
  }
description Generated from: openconfig-routing-policy - variables: 2